### PR TITLE
improving set_cookie security

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -70,7 +70,7 @@ def auth():
 		if token:
 			expiry_date = datetime.datetime.now() + datetime.timedelta(days=30)
 			response = make_response(redirect(url_for('.home')))
-			response.set_cookie('token', token, expires=expiry_date)
+			response.set_cookie('token', token, expires=expiry_date, secure=True, httponly=True, samesite='Lax')
 			return response
 	return redirect(url_for('.login'))
 
@@ -78,13 +78,13 @@ def auth():
 def logout():
 	authentication.removeToken()
 	response = make_response(redirect(url_for('.login')))
-	response.set_cookie('token', '', expires=0)
+	response.set_cookie('token', '', expires=0, secure=True, httponly=True, samesite='Lax')
 	return response
 
 if __name__ == "__main__":
 	if settings['SSL']['Enabled']:
 		app.run(host = settings['Host'], 
-				port = settings['Port'], 
+				port = settings['Port'],
 				threaded = settings['Threaded'], 
 				debug = settings['Debug'], 
 				ssl_context = (settings['cerPath'], settings['keyPath']))


### PR DESCRIPTION
Hey Qasim,

I am part of a team that builds free program analysis tool (called Bento) for Flask and other python web frameworks. While we were scanning GitHub projects for issues, it triggered a warning for the set_cookie method on your app. 

The `auth()` function calls `set_cookie()`.  Setting the `secure`, `httponly`, and `samesite` flags improves the security against XSS attacks (https://techblog.topdesk.com/security/cookie-security/) and it is also a Flask best practice (https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options). So, hopefully, you'll find this PR helpful. 

Between, Bento spotted a few more issues, notably the "Use of unsafe yaml load", but I didn't want to mess with too many files. If you are curious, feel free to download Bento from https://bento.dev and take a look at them.